### PR TITLE
Changes to display pages other than index correctly

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -13,6 +13,9 @@
 .git
 .gitignore
 
+# Node modules:
+node_modules/
+
 # Python pycache:
 __pycache__/
 # Ignored by the build system

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# Hello Framework
+# Framework - Google Cloud Integration
+
+This is a project integrating Observable Framework with Google Cloud using Google App Engine. 
+
+Several files are used for the integration, while the remaining files are part of the Hello Framework template from Observable.
+1. The deploy.sh file assists in setting up the Google Cloud project for hosting
+2. The app.yaml, main.py, and requirements.txt files are required in generating the Google App Engine app.
+
+To deploy the app you will need to install Google SDK to access to Google Cloud via the terminal. 
+
+## Hello Framework
 
 This is an [Observable Framework](https://observablehq.com/framework) project. To start the local preview server, run:
 

--- a/app.yaml
+++ b/app.yaml
@@ -3,13 +3,13 @@ entrypoint: gunicorn -b :$PORT main:app
 
 handlers:
 - url: /
-  static_files: index.html
-  upload: index.html
+  static_files: dist/index.html
+  upload: dist/index.html
   secure: always
   login: required
 
 - url: /(.*)
-  static_files: \1
-  upload: .*
+  static_files: dist/\1
+  upload: dist/.*
   secure: always
   login: required

--- a/main.py
+++ b/main.py
@@ -5,11 +5,11 @@ app = Flask(__name__)
 
 @app.route('/')
 def serve_index():
-    return send_from_directory('.', 'index.html')
+    return send_from_directory('dist', 'index.html')
 
 @app.route('/<path:path>')
 def serve_file(path):
-    return send_from_directory('.', path)
+    return send_from_directory('dist', path)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))

--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -33,5 +33,5 @@ export default {
   // search: true, // activate search
   // linkify: true, // convert URLs in Markdown to links
   // typographer: false, // smart quotes and other typographic improvements
-  // cleanUrls: true, // drop .html from URLs
+  cleanUrls: false, // drop .html from URLs
 };


### PR DESCRIPTION
When running npm run build, the dist directory is created that contains the html files, so I altered the paths to include the dist directory. Pages other than the index were not displaying correctly, so I updated the observable config file to set cleanUrls to false. I also updated the README for more context about the Google Cloud integration. (I realized these should probably be separate pull requests - my apologies, I am relatively new to git collaboration!)